### PR TITLE
Add target="_blank" to external links

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,16 +7,12 @@
     class="flex flex-row w-full items-center justify-end py-10 space-x-7"
     aria-label="global"
   >
-    <a
-      href="/resume.pdf"
-      class="font-medium"
-      target="_blank"
-    >R&eacute;sum&eacute;</a>
-    <a
-      href="https://www.linkedin.com/in/jeffreypliang/" 
-      class="font-medium" 
-      target="_blank"
-    >LinkedIn</a>
+    <a href="/resume.pdf" class="font-medium" target="_blank">
+      R&eacute;sum&eacute;
+    </a>
+    <a href="https://www.linkedin.com/in/jeffreypliang/" class="font-medium" target="_blank">
+      LinkedIn
+    </a>
   </nav>
 </header>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,10 +7,16 @@
     class="flex flex-row w-full items-center justify-end py-10 space-x-7"
     aria-label="global"
   >
-    <a href="/resume.pdf" class="font-medium">R&eacute;sum&eacute;</a>
-    <a href="https://www.linkedin.com/in/jeffreypliang/" class="font-medium"
-      >LinkedIn</a
-    >
+    <a
+      href="/resume.pdf"
+      class="font-medium"
+      target="_blank"
+    >R&eacute;sum&eacute;</a>
+    <a
+      href="https://www.linkedin.com/in/jeffreypliang/" 
+      class="font-medium" 
+      target="_blank"
+    >LinkedIn</a>
   </nav>
 </header>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,23 +22,26 @@ import Section from "../components/Section.astro";
     <Section title="About">
       <p>
         I'm a software engineer at Databricks, improving the reliability and
-        performance of <a
-          href="https://www.databricks.com/blog/introducing-databricks-lakeflow"
-          >Lakeflow Pipelines</a
-        > and <a href="https://www.databricks.com/product/delta-live-tables"
-          >Delta Live Tables</a
-        >.
+        performance of 
+        <a href="https://www.databricks.com/blog/introducing-databricks-lakeflow" target="_blank">
+          Lakeflow Pipelines
+        </a> and 
+        <a href="https://www.databricks.com/product/delta-live-tables" target="_blank">
+          Delta Live Tables
+        </a>.
       </p>
       <p>
         Previously, I completed two software engineering internships at Google,
         where I worked on Google Maps data infrastructure and Google Ads
-        <a
-          href="https://ads.google.com/intl/en_us/home/campaigns/performance-max/"
-          >Performance Max campaigns</a
-        >. I graduated with a bachelor's degree in computer science from the
-        University of California, Berkeley, where I also TA'd the <a
-          href="https://cs186berkeley.net/">database systems course</a
-        > for four semesters.
+        <a href="https://ads.google.com/intl/en_us/home/campaigns/performance-max/" target="_blank">
+          Performance Max campaigns
+        </a>.
+        I graduated with a bachelor's degree in computer science from the
+        University of California, Berkeley, where I also TA'd the
+        <a href="https://cs186berkeley.net/" target="_blank">
+          database systems course
+        </a>
+        for four semesters.
       </p>
       <p>
         In my free time, I enjoy reading, listening to podcasts, solving


### PR DESCRIPTION
Adds the `target="_blank"` property to external links, which opens them in a new tab when the user clicks on them, rather than replacing the current page context. This will keep the site open while they're viewing external resources.

[Demo](https://github.com/user-attachments/assets/a81e8497-f77b-49ae-844f-60e3affa7644)
